### PR TITLE
Add kernel build script and profile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # compute-server
+
+This repository contains scripts used to configure compute nodes.
+
+## Kernel build
+
+`scripts/build_kernel.sh` clones and compiles a Linux kernel and installs it on the node. The script is invoked automatically from `profile.py` via the environment variable `PROFILE_CONF_COMMAND_KERNEL`. Extra arguments can be supplied through `PROFILE_CONF_COMMAND_KERNEL_ARGS` which correspond to the optional `kernelArgs` profile parameter.
+

--- a/profile.py
+++ b/profile.py
@@ -165,6 +165,15 @@ pc.defineParameter(
     advanced=True
 )
 
+# Optional arguments for the kernel build script
+pc.defineParameter(
+    "kernelArgs",
+    "Arguments for build_kernel.sh",
+    portal.ParameterType.STRING,
+    "",
+    advanced=True,
+)
+
 
 
 params = pc.bindParameters()
@@ -223,6 +232,11 @@ if params.isolcpusNumber > 0:
 else:
     profileConfigs += "PROFILE_CONF_COMMAND_NOREBOOT='touch' "
     profileConfigs += "PROFILE_CONF_COMMAND_NOREBOOT_ARGS='/local/.noreboot' "
+
+# Kernel build script
+profileConfigs += "PROFILE_CONF_COMMAND_KERNEL='/local/repository/scripts/build_kernel.sh' "
+if params.kernelArgs:
+    profileConfigs += "PROFILE_CONF_COMMAND_KERNEL_ARGS='%s' " % (params.kernelArgs)
 
 # Machines
 count = 0

--- a/scripts/build_kernel.sh
+++ b/scripts/build_kernel.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Build and install a custom Linux kernel
+# This replicates the steps used in the Azure/GCP setup.
+
+set -e
+
+REPO_URL="https://github.com/torvalds/linux.git"
+BRANCH="master"
+SRC_DIR="/tmp/linux-src"
+
+# Allow arguments to override repository, branch or other options
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)
+            REPO_URL="$2"; shift 2;;
+        --branch)
+            BRANCH="$2"; shift 2;;
+        *)
+            break;;
+    esac
+done
+
+# Install dependencies
+sudo apt-get update
+sudo apt-get install -y build-essential git libncurses-dev bison flex libssl-dev libelf-dev
+
+# Fetch sources
+rm -rf "$SRC_DIR"
+git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$SRC_DIR"
+cd "$SRC_DIR"
+
+# Configure and build
+make olddefconfig
+make -j"$(nproc)"
+
+# Install
+sudo make modules_install
+sudo make install
+sudo update-grub
+
+# Leave sources in place for inspection
+
+echo "Kernel build complete"
+


### PR DESCRIPTION
## Summary
- add `scripts/build_kernel.sh` for cloning and building a linux kernel
- include `PROFILE_CONF_COMMAND_KERNEL` and optional args in `profile.py`
- expose `kernelArgs` parameter to supply build arguments
- document new script and variables in README

## Testing
- `python3 -m py_compile profile.py`
- `bash -n scripts/build_kernel.sh`


------
https://chatgpt.com/codex/tasks/task_e_6846f5c2a9fc8320a0e0bbaf524a0e1c